### PR TITLE
Add support for Litra Beam

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -27,7 +27,7 @@ export const findDevice = (): Device | null => {
   const matchingDevice = HID.devices().find(
     (device) =>
       device.vendorId === VENDOR_ID &&
-      PRODUCT_IDS.includes(device.productId, 0) &&
+      PRODUCT_IDS.includes(device.productId) &&
       device.usagePage === USAGE_PAGE,
   );
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -3,7 +3,10 @@ import HID from 'node-hid';
 import { integerToBytes, padRight, percentageWithinRange } from './utils';
 
 const VENDOR_ID = 0x046d;
-const PRODUCT_ID = 0xc900;
+const PRODUCT_IDS = [
+  0xc900, // Litra Glow
+  0xc901, // Litra Beam
+];
 const USAGE_PAGE = 0xff43;
 
 // Conforms to the interface of `node-hid`'s `HID.HID`. Useful for mocking.
@@ -24,7 +27,7 @@ export const findDevice = (): Device | null => {
   const matchingDevice = HID.devices().find(
     (device) =>
       device.vendorId === VENDOR_ID &&
-      device.productId === PRODUCT_ID &&
+      PRODUCT_IDS.includes(device.productId, 0) &&
       device.usagePage === USAGE_PAGE,
   );
 


### PR DESCRIPTION
Please add support for Litra Beam, so the user may control this light as well:
https://www.logitech.com/en-eu/products/lighting/litra-beam.html

Here is a reading for connected Litra Beam via USB `ioreg -p IOUSB -l -b | grep -E "@|idVendor|idProduct|bcdDevice"`:
```
Litra Beam@00122000  <class IOUSBHostDevice, id 0x10001c606, registered, matched, active, busy 0 (54 ms), retain 32>
    | |       "idProduct" = 51457
    | |       "bcdDevice" = 256
    | |       "idVendor" = 1133
```