### PR TITLE
Add support for the Logitech Litra Beam device and rename the package from `litra-glow` to `litra`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Logitech Litra Glow
+# Logitech Litra
 
-This JavaScript driver allows you to control your [Logitech Litra Glow](https://www.logitech.com/en-gb/products/lighting/litra-glow.946-000002.html) light using a CLI and from your JavaScript code.
+This JavaScript driver allows you to control [Logitech Litra Glow](https://www.logitech.com/en-gb/products/lighting/litra-glow.946-000002.html) and [Logitech Litra Beam](https://www.logitech.com/en-gb/products/lighting/litra-beam.946-000007.html) lights using a CLI and from your JavaScript code.
 
 With this driver, you can:
 
@@ -30,9 +30,9 @@ npm install --save litra-glow
 
 ### Usage
 
-#### Checking if a Litra Glow is plugged in
+#### Checking if a Litra device is plugged in
 
-The `findDevice` function checks your computer to find whether a Logitech Litra Glow is plugged in. 
+The `findDevice` function checks your computer to find whether a Logitech Litra device is plugged in. 
 
 If it is, it returns an object representing the device, which you can pass into other function. If it isn't, it returns `null`.
 
@@ -42,15 +42,17 @@ import { findDevice } from 'litra-glow';
 const device = findDevice();
 
 if (device) {
+  console.log(`Found a ${device.type} device connected`);
+
   // Do something
 } else {
   // Blow up
 }
 ```
 
-If you're a *huge* fan of the Litra Glow and you have multiple plugged in at the same time, it'll return whatever one it happens to find first.
+If you're a *huge* fan of Litra devices and you have multiple plugged in at the same time, it'll return whatever one it happens to find first.
 
-#### Turning your Litra Glow on or off
+#### Turning your Litra device on or off
 
 Find your device with `findDevice`, and then use the simple `turnOn` and `turnOff` functions. They just take one parameter: the device.
 
@@ -66,16 +68,25 @@ if (device) {
 }
 ```
 
-#### Setting the brightness of your Litra Glow
+#### Setting the brightness of your Litra device
 
-You can set the brightness of your Litra Glow, measured in Lumen, using the `setBrightnessInLumen` function. The Litra Glow supports brightness between 20 and 250 Lumen:
+You can set the brightness of your Litra device, measured in Lumen, using the `setBrightnessInLumen` function. 
+
+The Litra Glow supports brightness between 20 and 250 Lumen. The Litra Beam supports brightness between 20 and 400 Lumen.
+
+You can programatically check what brightness levels are supported by your device. Once you know what brightness levels are supported, you can set the brightness in Lumen. If you try to set a value that isn't allowed by your device, an error will be thrown:
 
 ```js
-import { findDevice, setBrightnessInLumen } from 'litra-glow';
+import { findDevice, getMaximumBrightnessInLumenForDevice, getMinimumBrightnessInLumenForDevice, setBrightnessInLumen } from 'litra-glow';
 
 const device = findDevice();
 
 if (device) {
+  const minimumBrightness = getMinimumBrightnessInLumenForDevice(device);
+  const maximumBrightness = getMaximumBrightnessInLumenForDevice(device);
+
+  console.log(`The minimum allowed brightness is ${minimumBrightness} and the maximum is ${maximumBrightness}`);
+
   setBrightnessInLumen(device, 150);
 }
 ```
@@ -92,21 +103,30 @@ if (device) {
 }
 ```
 
-#### Setting the temperature of your Litra Glow
+#### Setting the temperature of your Litra device
 
-You can set the temperature of your Litra Glow, measured in Kelvin, using the `setTemperatureInKelvin` function. The Litra Glow supports temperature between 2700 and 6500 Kelvin:
+You can set the temperature of your Litra device, measured in Kelvin, using the `setTemperatureInKelvin` function.
+
+Both the Litra Glow and Litra Beam support temperatures between 2700 and 6500 Kelvin.
+
+You can check programatically what temperature levels are supported by your device. Once you know what temperature levels are supported, you can set the temperature in Kelvin. If you try to set a value that isn't allowed by your device, an error will be thrown:
 
 ```js
-import { findDevice, setTemperatureInKelvin } from 'litra-glow';
+import { findDevice, getMaximumTemperatureInKelvinForDevice, getMinimumTemperatureInKelvinForDevice, setTemperatureInKelvin } from 'litra-glow';
 
 const device = findDevice();
 
 if (device) {
-  setTemperatureInKelvin(device, 4500);
+  const minimumTemperature = getMinimumTemperatureInKelvinForDevice(device);
+  const maximumTemperature = getMaximumTemperatureInKelvinForDevice(device);
+
+  console.log(`The minimum allowed temperature is ${minimumTemperature} and the maximum is ${maximumTemperature}`);
+
+  setTemperatureInKelvin(device, 6500);
 }
 ```
 
-You can also set brightness level to a percentage with `setTemperaturePercentage` if you don't want to think in Lumen:
+You can also set temperature level to a percentage with `setTemperaturePercentage` if you don't want to think in Kelvin:
 
 ```js
 import { findDevice, setTemperaturePercentage } from 'litra-glow';

--- a/dist/commonjs/driver.d.ts
+++ b/dist/commonjs/driver.d.ts
@@ -1,39 +1,46 @@
 /// <reference types="node" />
+export declare enum DeviceType {
+    LitraGlow = "litra_glow",
+    LitraBeam = "litra_beam"
+}
 export interface Device {
-    write: (values: number[] | Buffer) => number;
+    hid: {
+        write: (values: number[] | Buffer) => number;
+    };
+    type: DeviceType;
 }
 /**
- * Finds your Logitech Litra Glow device and returns it. Returns `null`
- * if a matching device cannot be found connected to your computer.
+ * Finds your Logitech Litra device and returns it. Returns `null` if a
+ * supported device cannot be found connected to your computer.
  *
- * @returns {Device, null} An object representing your Logitech Litra
- * Glow device, passed into other functions like `turnOn` and
- * `setTemperatureInKelvin` - or `null` if a matching device cannot be
- * found connected to your computer.
+ * @returns {Device, null} An object representing your Logitech Litra device,
+ * passed into other functions like `turnOn` and `setTemperatureInKelvin` -
+ * or `null` if a matching device cannot be found connected to your computer.
  */
 export declare const findDevice: () => Device | null;
 /**
- * Turns your Logitech Litra Glow device on.
+ * Turns your Logitech Litra device on.
  *
  * @param {Device} device The device to set the temperature of
  */
 export declare const turnOn: (device: Device) => void;
 /**
- * Turns your Logitech Litra Glow device off.
+ * Turns your Logitech Litra device off.
  *
  * @param {Device} device The device to set the temperature of
  */
 export declare const turnOff: (device: Device) => void;
 /**
- * Sets the temperature of your Logitech Litra Glow device
+ * Sets the temperature of your Logitech Litra device
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} temperatureInKelvin The temperature to set in Kelvin, which
- * must be an integer between 2700 and 6500
+ * @param {number} temperatureInKelvin The temperature to set in Kelvin. Use the
+ *  `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice`
+ *  functions to get the minimum and maximum temperature for your device.
  */
 export declare const setTemperatureInKelvin: (device: Device, temperatureInKelvin: number) => void;
 /**
- * Set the temperature of your Logitech Litra Glow device to a percentage
+ * Set the temperature of your Logitech Litra device to a percentage
  * of the device's maximum temperature
  *
  * @param {Device} device The device to set the temperature of
@@ -41,18 +48,47 @@ export declare const setTemperatureInKelvin: (device: Device, temperatureInKelvi
  */
 export declare const setTemperaturePercentage: (device: Device, temperaturePercentage: number) => void;
 /**
- * Sets the brightness of your Logitech Litra Glow device, measured in Lumen
+ * Sets the brightness of your Logitech Litra device, measured in Lumen
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} brightnessInLumens The brightness to set in Lumen, which
- * must be an integer between 20 and 250
+ * @param {number} brightnessInLumen The brightness to set in Lumen. Use the
+ *  `getMinimumBrightnessInLumenForDevice` and `getMaximumBrightnessInLumenForDevice`
+ *  functions to get the minimum and maximum brightness for your device.
  */
 export declare const setBrightnessInLumen: (device: Device, brightnessInLumen: number) => void;
 /**
- * Set the brightness of your Logitech Litra Glow device to a percentage
+ * Set the brightness of your Logitech Litra device to a percentage
  * of the device's maximum brightness
  *
  * @param {Device} device The device to set the brightness of
  * @param {number} brightnessPercentage The percentage to set the brightness to
  */
 export declare const setBrightnessPercentage: (device: Device, brightnessPercentage: number) => void;
+/**
+ * Gets the minimum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the minimum brightness for
+ * @returns {number} The minimum brightness in Lumen supported by the device
+ */
+export declare const getMinimumBrightnessInLumenForDevice: (device: Device) => number;
+/**
+ * Gets the maximum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the maximum brightness for
+ * @returns {number} The maximum brightness in Lumen supported by the device
+ */
+export declare const getMaximumBrightnessInLumenForDevice: (device: Device) => number;
+/**
+ * Gets the minimum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the minimum temperature for
+ * @returns {number} The minimum temperature in Kelvin supported by the device
+ */
+export declare const getMinimumTemperatureInKelvinForDevice: (device: Device) => number;
+/**
+ * Gets the maximum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the maximum temperature for
+ * @returns {number} The maximum temperature in Kelvin supported by the device
+ */
+export declare const getMaximumTemperatureInKelvinForDevice: (device: Device) => number;

--- a/dist/commonjs/driver.js
+++ b/dist/commonjs/driver.js
@@ -3,27 +3,53 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setBrightnessPercentage = exports.setBrightnessInLumen = exports.setTemperaturePercentage = exports.setTemperatureInKelvin = exports.turnOff = exports.turnOn = exports.findDevice = void 0;
+exports.getMaximumTemperatureInKelvinForDevice = exports.getMinimumTemperatureInKelvinForDevice = exports.getMaximumBrightnessInLumenForDevice = exports.getMinimumBrightnessInLumenForDevice = exports.setBrightnessPercentage = exports.setBrightnessInLumen = exports.setTemperaturePercentage = exports.setTemperatureInKelvin = exports.turnOff = exports.turnOn = exports.findDevice = exports.DeviceType = void 0;
 const node_hid_1 = __importDefault(require("node-hid"));
 const utils_1 = require("./utils");
+var DeviceType;
+(function (DeviceType) {
+    DeviceType["LitraGlow"] = "litra_glow";
+    DeviceType["LitraBeam"] = "litra_beam";
+})(DeviceType = exports.DeviceType || (exports.DeviceType = {}));
 const VENDOR_ID = 0x046d;
-const PRODUCT_ID = 0xc900;
+const PRODUCT_IDS = [
+    0xc900,
+    0xc901, // Litra Beam
+];
 const USAGE_PAGE = 0xff43;
+const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 20,
+    [DeviceType.LitraBeam]: 20,
+};
+const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 250,
+    [DeviceType.LitraBeam]: 400,
+};
+const MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 2700,
+    [DeviceType.LitraBeam]: 2700,
+};
+const MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 6500,
+    [DeviceType.LitraBeam]: 6500,
+};
 /**
- * Finds your Logitech Litra Glow device and returns it. Returns `null`
- * if a matching device cannot be found connected to your computer.
+ * Finds your Logitech Litra device and returns it. Returns `null` if a
+ * supported device cannot be found connected to your computer.
  *
- * @returns {Device, null} An object representing your Logitech Litra
- * Glow device, passed into other functions like `turnOn` and
- * `setTemperatureInKelvin` - or `null` if a matching device cannot be
- * found connected to your computer.
+ * @returns {Device, null} An object representing your Logitech Litra device,
+ * passed into other functions like `turnOn` and `setTemperatureInKelvin` -
+ * or `null` if a matching device cannot be found connected to your computer.
  */
 const findDevice = () => {
     const matchingDevice = node_hid_1.default.devices().find((device) => device.vendorId === VENDOR_ID &&
-        device.productId === PRODUCT_ID &&
+        PRODUCT_IDS.includes(device.productId) &&
         device.usagePage === USAGE_PAGE);
     if (matchingDevice) {
-        return new node_hid_1.default.HID(matchingDevice.path);
+        return {
+            type: getDeviceTypeByProductId(matchingDevice.productId),
+            hid: new node_hid_1.default.HID(matchingDevice.path),
+        };
     }
     else {
         return null;
@@ -31,45 +57,46 @@ const findDevice = () => {
 };
 exports.findDevice = findDevice;
 /**
- * Turns your Logitech Litra Glow device on.
+ * Turns your Logitech Litra device on.
  *
  * @param {Device} device The device to set the temperature of
  */
 const turnOn = (device) => {
-    device.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
+    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
 };
 exports.turnOn = turnOn;
 /**
- * Turns your Logitech Litra Glow device off.
+ * Turns your Logitech Litra device off.
  *
  * @param {Device} device The device to set the temperature of
  */
 const turnOff = (device) => {
-    device.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
+    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
 };
 exports.turnOff = turnOff;
-const MINIMUM_TEMPERATURE_IN_KELVIN = 2700;
-const MAXIMUM_TEMPERATURE_IN_KELVIN = 6500;
 /**
- * Sets the temperature of your Logitech Litra Glow device
+ * Sets the temperature of your Logitech Litra device
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} temperatureInKelvin The temperature to set in Kelvin, which
- * must be an integer between 2700 and 6500
+ * @param {number} temperatureInKelvin The temperature to set in Kelvin. Use the
+ *  `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice`
+ *  functions to get the minimum and maximum temperature for your device.
  */
 const setTemperatureInKelvin = (device, temperatureInKelvin) => {
     if (!Number.isInteger(temperatureInKelvin)) {
         throw 'Provided temperature must be an integer';
     }
-    if (temperatureInKelvin < MINIMUM_TEMPERATURE_IN_KELVIN ||
-        temperatureInKelvin > MAXIMUM_TEMPERATURE_IN_KELVIN) {
-        throw `Provided temperature must be between ${MINIMUM_TEMPERATURE_IN_KELVIN} and ${MAXIMUM_TEMPERATURE_IN_KELVIN}`;
+    const minimumTemperature = (0, exports.getMinimumTemperatureInKelvinForDevice)(device);
+    const maximumTemperature = (0, exports.getMaximumTemperatureInKelvinForDevice)(device);
+    if (temperatureInKelvin < minimumTemperature ||
+        temperatureInKelvin > maximumTemperature) {
+        throw `Provided temperature must be between ${minimumTemperature} and ${maximumTemperature} for this device`;
     }
-    device.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x9c, ...(0, utils_1.integerToBytes)(temperatureInKelvin)], 20, 0x00));
+    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x9c, ...(0, utils_1.integerToBytes)(temperatureInKelvin)], 20, 0x00));
 };
 exports.setTemperatureInKelvin = setTemperatureInKelvin;
 /**
- * Set the temperature of your Logitech Litra Glow device to a percentage
+ * Set the temperature of your Logitech Litra device to a percentage
  * of the device's maximum temperature
  *
  * @param {Device} device The device to set the temperature of
@@ -79,33 +106,35 @@ const setTemperaturePercentage = (device, temperaturePercentage) => {
     if (temperaturePercentage < 0 || temperaturePercentage > 100) {
         throw 'Percentage must be between 0 and 100';
     }
+    const minimumTemperature = (0, exports.getMinimumTemperatureInKelvinForDevice)(device);
+    const maximumTemperature = (0, exports.getMaximumTemperatureInKelvinForDevice)(device);
     return (0, exports.setTemperatureInKelvin)(device, temperaturePercentage === 0
-        ? MINIMUM_TEMPERATURE_IN_KELVIN
-        : (0, utils_1.percentageWithinRange)(temperaturePercentage, MINIMUM_TEMPERATURE_IN_KELVIN, MAXIMUM_TEMPERATURE_IN_KELVIN));
+        ? minimumTemperature
+        : (0, utils_1.percentageWithinRange)(temperaturePercentage, minimumTemperature, maximumTemperature));
 };
 exports.setTemperaturePercentage = setTemperaturePercentage;
-const MINIMUM_BRIGHTNESS_IN_LUMEN = 20;
-const MAXIMUM_BRIGHTNESS_IN_LUMEN = 250;
 /**
- * Sets the brightness of your Logitech Litra Glow device, measured in Lumen
+ * Sets the brightness of your Logitech Litra device, measured in Lumen
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} brightnessInLumens The brightness to set in Lumen, which
- * must be an integer between 20 and 250
+ * @param {number} brightnessInLumen The brightness to set in Lumen. Use the
+ *  `getMinimumBrightnessInLumenForDevice` and `getMaximumBrightnessInLumenForDevice`
+ *  functions to get the minimum and maximum brightness for your device.
  */
 const setBrightnessInLumen = (device, brightnessInLumen) => {
     if (!Number.isInteger(brightnessInLumen)) {
         throw 'Provided brightness must be an integer';
     }
-    if (brightnessInLumen < MINIMUM_BRIGHTNESS_IN_LUMEN ||
-        brightnessInLumen > MAXIMUM_BRIGHTNESS_IN_LUMEN) {
-        throw `Provided brightness must be between ${MINIMUM_BRIGHTNESS_IN_LUMEN} and ${MAXIMUM_BRIGHTNESS_IN_LUMEN}`;
+    const minimumBrightness = (0, exports.getMinimumBrightnessInLumenForDevice)(device);
+    const maximumBrightness = (0, exports.getMaximumBrightnessInLumenForDevice)(device);
+    if (brightnessInLumen < minimumBrightness || brightnessInLumen > maximumBrightness) {
+        throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
     }
-    device.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+    device.hid.write((0, utils_1.padRight)([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
 };
 exports.setBrightnessInLumen = setBrightnessInLumen;
 /**
- * Set the brightness of your Logitech Litra Glow device to a percentage
+ * Set the brightness of your Logitech Litra device to a percentage
  * of the device's maximum brightness
  *
  * @param {Device} device The device to set the brightness of
@@ -115,8 +144,66 @@ const setBrightnessPercentage = (device, brightnessPercentage) => {
     if (brightnessPercentage < 0 || brightnessPercentage > 100) {
         throw 'Percentage must be between 0 and 100';
     }
+    const minimumBrightness = (0, exports.getMinimumBrightnessInLumenForDevice)(device);
+    const maximumBrightness = (0, exports.getMaximumBrightnessInLumenForDevice)(device);
     return (0, exports.setBrightnessInLumen)(device, brightnessPercentage === 0
-        ? MINIMUM_BRIGHTNESS_IN_LUMEN
-        : (0, utils_1.percentageWithinRange)(brightnessPercentage, MINIMUM_BRIGHTNESS_IN_LUMEN, MAXIMUM_BRIGHTNESS_IN_LUMEN));
+        ? minimumBrightness
+        : (0, utils_1.percentageWithinRange)(brightnessPercentage, minimumBrightness, maximumBrightness));
 };
 exports.setBrightnessPercentage = setBrightnessPercentage;
+/**
+ * Gets the type of a Logitech Litra device by its product IOD
+ *
+ * @param {number} productId The product ID of the device
+ * @returns {DeviceType} The type of the device
+ */
+const getDeviceTypeByProductId = (productId) => {
+    switch (productId) {
+        case 0xc900:
+            return DeviceType.LitraGlow;
+        case 0xc901:
+            return DeviceType.LitraBeam;
+        default:
+            throw 'Unknown device type';
+    }
+};
+/**
+ * Gets the minimum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the minimum brightness for
+ * @returns {number} The minimum brightness in Lumen supported by the device
+ */
+const getMinimumBrightnessInLumenForDevice = (device) => {
+    return MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+exports.getMinimumBrightnessInLumenForDevice = getMinimumBrightnessInLumenForDevice;
+/**
+ * Gets the maximum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the maximum brightness for
+ * @returns {number} The maximum brightness in Lumen supported by the device
+ */
+const getMaximumBrightnessInLumenForDevice = (device) => {
+    return MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+exports.getMaximumBrightnessInLumenForDevice = getMaximumBrightnessInLumenForDevice;
+/**
+ * Gets the minimum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the minimum temperature for
+ * @returns {number} The minimum temperature in Kelvin supported by the device
+ */
+const getMinimumTemperatureInKelvinForDevice = (device) => {
+    return MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
+};
+exports.getMinimumTemperatureInKelvinForDevice = getMinimumTemperatureInKelvinForDevice;
+/**
+ * Gets the maximum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the maximum temperature for
+ * @returns {number} The maximum temperature in Kelvin supported by the device
+ */
+const getMaximumTemperatureInKelvinForDevice = (device) => {
+    return MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
+};
+exports.getMaximumTemperatureInKelvinForDevice = getMaximumTemperatureInKelvinForDevice;

--- a/dist/esm/driver.d.ts
+++ b/dist/esm/driver.d.ts
@@ -1,39 +1,46 @@
 /// <reference types="node" />
+export declare enum DeviceType {
+    LitraGlow = "litra_glow",
+    LitraBeam = "litra_beam"
+}
 export interface Device {
-    write: (values: number[] | Buffer) => number;
+    hid: {
+        write: (values: number[] | Buffer) => number;
+    };
+    type: DeviceType;
 }
 /**
- * Finds your Logitech Litra Glow device and returns it. Returns `null`
- * if a matching device cannot be found connected to your computer.
+ * Finds your Logitech Litra device and returns it. Returns `null` if a
+ * supported device cannot be found connected to your computer.
  *
- * @returns {Device, null} An object representing your Logitech Litra
- * Glow device, passed into other functions like `turnOn` and
- * `setTemperatureInKelvin` - or `null` if a matching device cannot be
- * found connected to your computer.
+ * @returns {Device, null} An object representing your Logitech Litra device,
+ * passed into other functions like `turnOn` and `setTemperatureInKelvin` -
+ * or `null` if a matching device cannot be found connected to your computer.
  */
 export declare const findDevice: () => Device | null;
 /**
- * Turns your Logitech Litra Glow device on.
+ * Turns your Logitech Litra device on.
  *
  * @param {Device} device The device to set the temperature of
  */
 export declare const turnOn: (device: Device) => void;
 /**
- * Turns your Logitech Litra Glow device off.
+ * Turns your Logitech Litra device off.
  *
  * @param {Device} device The device to set the temperature of
  */
 export declare const turnOff: (device: Device) => void;
 /**
- * Sets the temperature of your Logitech Litra Glow device
+ * Sets the temperature of your Logitech Litra device
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} temperatureInKelvin The temperature to set in Kelvin, which
- * must be an integer between 2700 and 6500
+ * @param {number} temperatureInKelvin The temperature to set in Kelvin. Use the
+ *  `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice`
+ *  functions to get the minimum and maximum temperature for your device.
  */
 export declare const setTemperatureInKelvin: (device: Device, temperatureInKelvin: number) => void;
 /**
- * Set the temperature of your Logitech Litra Glow device to a percentage
+ * Set the temperature of your Logitech Litra device to a percentage
  * of the device's maximum temperature
  *
  * @param {Device} device The device to set the temperature of
@@ -41,18 +48,47 @@ export declare const setTemperatureInKelvin: (device: Device, temperatureInKelvi
  */
 export declare const setTemperaturePercentage: (device: Device, temperaturePercentage: number) => void;
 /**
- * Sets the brightness of your Logitech Litra Glow device, measured in Lumen
+ * Sets the brightness of your Logitech Litra device, measured in Lumen
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} brightnessInLumens The brightness to set in Lumen, which
- * must be an integer between 20 and 250
+ * @param {number} brightnessInLumen The brightness to set in Lumen. Use the
+ *  `getMinimumBrightnessInLumenForDevice` and `getMaximumBrightnessInLumenForDevice`
+ *  functions to get the minimum and maximum brightness for your device.
  */
 export declare const setBrightnessInLumen: (device: Device, brightnessInLumen: number) => void;
 /**
- * Set the brightness of your Logitech Litra Glow device to a percentage
+ * Set the brightness of your Logitech Litra device to a percentage
  * of the device's maximum brightness
  *
  * @param {Device} device The device to set the brightness of
  * @param {number} brightnessPercentage The percentage to set the brightness to
  */
 export declare const setBrightnessPercentage: (device: Device, brightnessPercentage: number) => void;
+/**
+ * Gets the minimum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the minimum brightness for
+ * @returns {number} The minimum brightness in Lumen supported by the device
+ */
+export declare const getMinimumBrightnessInLumenForDevice: (device: Device) => number;
+/**
+ * Gets the maximum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the maximum brightness for
+ * @returns {number} The maximum brightness in Lumen supported by the device
+ */
+export declare const getMaximumBrightnessInLumenForDevice: (device: Device) => number;
+/**
+ * Gets the minimum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the minimum temperature for
+ * @returns {number} The minimum temperature in Kelvin supported by the device
+ */
+export declare const getMinimumTemperatureInKelvinForDevice: (device: Device) => number;
+/**
+ * Gets the maximum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the maximum temperature for
+ * @returns {number} The maximum temperature in Kelvin supported by the device
+ */
+export declare const getMaximumTemperatureInKelvinForDevice: (device: Device) => number;

--- a/dist/esm/driver.js
+++ b/dist/esm/driver.js
@@ -1,65 +1,92 @@
 import HID from 'node-hid';
 import { integerToBytes, padRight, percentageWithinRange } from './utils';
+export var DeviceType;
+(function (DeviceType) {
+    DeviceType["LitraGlow"] = "litra_glow";
+    DeviceType["LitraBeam"] = "litra_beam";
+})(DeviceType || (DeviceType = {}));
 const VENDOR_ID = 0x046d;
-const PRODUCT_ID = 0xc900;
+const PRODUCT_IDS = [
+    0xc900,
+    0xc901, // Litra Beam
+];
 const USAGE_PAGE = 0xff43;
+const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 20,
+    [DeviceType.LitraBeam]: 20,
+};
+const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 250,
+    [DeviceType.LitraBeam]: 400,
+};
+const MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 2700,
+    [DeviceType.LitraBeam]: 2700,
+};
+const MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+    [DeviceType.LitraGlow]: 6500,
+    [DeviceType.LitraBeam]: 6500,
+};
 /**
- * Finds your Logitech Litra Glow device and returns it. Returns `null`
- * if a matching device cannot be found connected to your computer.
+ * Finds your Logitech Litra device and returns it. Returns `null` if a
+ * supported device cannot be found connected to your computer.
  *
- * @returns {Device, null} An object representing your Logitech Litra
- * Glow device, passed into other functions like `turnOn` and
- * `setTemperatureInKelvin` - or `null` if a matching device cannot be
- * found connected to your computer.
+ * @returns {Device, null} An object representing your Logitech Litra device,
+ * passed into other functions like `turnOn` and `setTemperatureInKelvin` -
+ * or `null` if a matching device cannot be found connected to your computer.
  */
 export const findDevice = () => {
     const matchingDevice = HID.devices().find((device) => device.vendorId === VENDOR_ID &&
-        device.productId === PRODUCT_ID &&
+        PRODUCT_IDS.includes(device.productId) &&
         device.usagePage === USAGE_PAGE);
     if (matchingDevice) {
-        return new HID.HID(matchingDevice.path);
+        return {
+            type: getDeviceTypeByProductId(matchingDevice.productId),
+            hid: new HID.HID(matchingDevice.path),
+        };
     }
     else {
         return null;
     }
 };
 /**
- * Turns your Logitech Litra Glow device on.
+ * Turns your Logitech Litra device on.
  *
  * @param {Device} device The device to set the temperature of
  */
 export const turnOn = (device) => {
-    device.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
+    device.hid.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
 };
 /**
- * Turns your Logitech Litra Glow device off.
+ * Turns your Logitech Litra device off.
  *
  * @param {Device} device The device to set the temperature of
  */
 export const turnOff = (device) => {
-    device.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
+    device.hid.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
 };
-const MINIMUM_TEMPERATURE_IN_KELVIN = 2700;
-const MAXIMUM_TEMPERATURE_IN_KELVIN = 6500;
 /**
- * Sets the temperature of your Logitech Litra Glow device
+ * Sets the temperature of your Logitech Litra device
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} temperatureInKelvin The temperature to set in Kelvin, which
- * must be an integer between 2700 and 6500
+ * @param {number} temperatureInKelvin The temperature to set in Kelvin. Use the
+ *  `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice`
+ *  functions to get the minimum and maximum temperature for your device.
  */
 export const setTemperatureInKelvin = (device, temperatureInKelvin) => {
     if (!Number.isInteger(temperatureInKelvin)) {
         throw 'Provided temperature must be an integer';
     }
-    if (temperatureInKelvin < MINIMUM_TEMPERATURE_IN_KELVIN ||
-        temperatureInKelvin > MAXIMUM_TEMPERATURE_IN_KELVIN) {
-        throw `Provided temperature must be between ${MINIMUM_TEMPERATURE_IN_KELVIN} and ${MAXIMUM_TEMPERATURE_IN_KELVIN}`;
+    const minimumTemperature = getMinimumTemperatureInKelvinForDevice(device);
+    const maximumTemperature = getMaximumTemperatureInKelvinForDevice(device);
+    if (temperatureInKelvin < minimumTemperature ||
+        temperatureInKelvin > maximumTemperature) {
+        throw `Provided temperature must be between ${minimumTemperature} and ${maximumTemperature} for this device`;
     }
-    device.write(padRight([0x11, 0xff, 0x04, 0x9c, ...integerToBytes(temperatureInKelvin)], 20, 0x00));
+    device.hid.write(padRight([0x11, 0xff, 0x04, 0x9c, ...integerToBytes(temperatureInKelvin)], 20, 0x00));
 };
 /**
- * Set the temperature of your Logitech Litra Glow device to a percentage
+ * Set the temperature of your Logitech Litra device to a percentage
  * of the device's maximum temperature
  *
  * @param {Device} device The device to set the temperature of
@@ -69,31 +96,33 @@ export const setTemperaturePercentage = (device, temperaturePercentage) => {
     if (temperaturePercentage < 0 || temperaturePercentage > 100) {
         throw 'Percentage must be between 0 and 100';
     }
+    const minimumTemperature = getMinimumTemperatureInKelvinForDevice(device);
+    const maximumTemperature = getMaximumTemperatureInKelvinForDevice(device);
     return setTemperatureInKelvin(device, temperaturePercentage === 0
-        ? MINIMUM_TEMPERATURE_IN_KELVIN
-        : percentageWithinRange(temperaturePercentage, MINIMUM_TEMPERATURE_IN_KELVIN, MAXIMUM_TEMPERATURE_IN_KELVIN));
+        ? minimumTemperature
+        : percentageWithinRange(temperaturePercentage, minimumTemperature, maximumTemperature));
 };
-const MINIMUM_BRIGHTNESS_IN_LUMEN = 20;
-const MAXIMUM_BRIGHTNESS_IN_LUMEN = 250;
 /**
- * Sets the brightness of your Logitech Litra Glow device, measured in Lumen
+ * Sets the brightness of your Logitech Litra device, measured in Lumen
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} brightnessInLumens The brightness to set in Lumen, which
- * must be an integer between 20 and 250
+ * @param {number} brightnessInLumen The brightness to set in Lumen. Use the
+ *  `getMinimumBrightnessInLumenForDevice` and `getMaximumBrightnessInLumenForDevice`
+ *  functions to get the minimum and maximum brightness for your device.
  */
 export const setBrightnessInLumen = (device, brightnessInLumen) => {
     if (!Number.isInteger(brightnessInLumen)) {
         throw 'Provided brightness must be an integer';
     }
-    if (brightnessInLumen < MINIMUM_BRIGHTNESS_IN_LUMEN ||
-        brightnessInLumen > MAXIMUM_BRIGHTNESS_IN_LUMEN) {
-        throw `Provided brightness must be between ${MINIMUM_BRIGHTNESS_IN_LUMEN} and ${MAXIMUM_BRIGHTNESS_IN_LUMEN}`;
+    const minimumBrightness = getMinimumBrightnessInLumenForDevice(device);
+    const maximumBrightness = getMaximumBrightnessInLumenForDevice(device);
+    if (brightnessInLumen < minimumBrightness || brightnessInLumen > maximumBrightness) {
+        throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
     }
-    device.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+    device.hid.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
 };
 /**
- * Set the brightness of your Logitech Litra Glow device to a percentage
+ * Set the brightness of your Logitech Litra device to a percentage
  * of the device's maximum brightness
  *
  * @param {Device} device The device to set the brightness of
@@ -103,7 +132,61 @@ export const setBrightnessPercentage = (device, brightnessPercentage) => {
     if (brightnessPercentage < 0 || brightnessPercentage > 100) {
         throw 'Percentage must be between 0 and 100';
     }
+    const minimumBrightness = getMinimumBrightnessInLumenForDevice(device);
+    const maximumBrightness = getMaximumBrightnessInLumenForDevice(device);
     return setBrightnessInLumen(device, brightnessPercentage === 0
-        ? MINIMUM_BRIGHTNESS_IN_LUMEN
-        : percentageWithinRange(brightnessPercentage, MINIMUM_BRIGHTNESS_IN_LUMEN, MAXIMUM_BRIGHTNESS_IN_LUMEN));
+        ? minimumBrightness
+        : percentageWithinRange(brightnessPercentage, minimumBrightness, maximumBrightness));
+};
+/**
+ * Gets the type of a Logitech Litra device by its product IOD
+ *
+ * @param {number} productId The product ID of the device
+ * @returns {DeviceType} The type of the device
+ */
+const getDeviceTypeByProductId = (productId) => {
+    switch (productId) {
+        case 0xc900:
+            return DeviceType.LitraGlow;
+        case 0xc901:
+            return DeviceType.LitraBeam;
+        default:
+            throw 'Unknown device type';
+    }
+};
+/**
+ * Gets the minimum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the minimum brightness for
+ * @returns {number} The minimum brightness in Lumen supported by the device
+ */
+export const getMinimumBrightnessInLumenForDevice = (device) => {
+    return MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+/**
+ * Gets the maximum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the maximum brightness for
+ * @returns {number} The maximum brightness in Lumen supported by the device
+ */
+export const getMaximumBrightnessInLumenForDevice = (device) => {
+    return MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+/**
+ * Gets the minimum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the minimum temperature for
+ * @returns {number} The minimum temperature in Kelvin supported by the device
+ */
+export const getMinimumTemperatureInKelvinForDevice = (device) => {
+    return MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
+};
+/**
+ * Gets the maximum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the maximum temperature for
+ * @returns {number} The maximum temperature in Kelvin supported by the device
+ */
+export const getMaximumTemperatureInKelvinForDevice = (device) => {
+    return MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "litra-glow",
+  "name": "litra",
   "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "litra-glow",
+      "name": "litra",
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
@@ -25,7 +25,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.0.3",
         "prettier": "^2.7.1",
-        "semantic-release": "^20.0.2",
+        "semantic-release": "^19.0.5",
         "ts-jest": "^29.0.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
@@ -1669,6 +1669,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -2512,6 +2518,17 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2656,18 +2673,19 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
+        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       }
     },
     "node_modules/create-require": {
@@ -2955,126 +2973,17 @@
       }
     },
     "node_modules/env-ci": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-8.0.0.tgz",
-      "integrity": "sha512-W+3BqGZozFua9MPeXpmTm5eYEBtGgL76jGu/pwMVp/L8PdECSCEWaIp7d4Mw7kuUrbUldK0oV0bNd6ZZjLiMiA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
       "dependencies": {
-        "execa": "^6.1.0",
-        "java-properties": "^1.0.2"
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
+        "java-properties": "^1.0.0"
       },
       "engines": {
-        "node": "^16.10 || >=18"
-      }
-    },
-    "node_modules/env-ci/node_modules/execa": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^3.0.1",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/env-ci/node_modules/human-signals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/env-ci/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=10.17"
       }
     },
     "node_modules/error-ex": {
@@ -3496,31 +3405,27 @@
       }
     },
     "node_modules/figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "dependencies": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
+        "escape-string-regexp": "^1.0.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3569,15 +3474,15 @@
       }
     },
     "node_modules/find-versions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
-      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "dev": true,
       "dependencies": {
-        "semver-regex": "^4.0.5"
+        "semver-regex": "^3.1.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3611,6 +3516,26 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -3865,15 +3790,12 @@
       }
     },
     "node_modules/hook-std": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
-      "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
       "dev": true,
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4192,18 +4114,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -5120,12 +5030,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
     "node_modules/lodash.capitalize": {
@@ -8263,12 +8167,12 @@
       }
     },
     "node_modules/p-each-series": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
-      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8335,15 +8239,12 @@
       }
     },
     "node_modules/p-reduce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
-      "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/p-retry": {
@@ -9112,9 +9013,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semantic-release": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-20.0.2.tgz",
-      "integrity": "sha512-K6TYMAnSUqM2oH0/0ZJErMzkx4SgV2dM8jh5RNGj1ANJ81z/u5XVaPPCZADAl7voEf6t2hd6YioLd0I6yXui2A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -9122,314 +9023,35 @@
         "@semantic-release/github": "^8.0.0",
         "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^4.0.1",
-        "cosmiconfig": "^8.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^8.0.0",
-        "execa": "^6.1.0",
-        "figures": "^5.0.0",
-        "find-versions": "^5.1.0",
+        "env-ci": "^5.0.0",
+        "execa": "^5.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^4.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^3.0.0",
-        "hosted-git-info": "^6.0.0",
-        "lodash-es": "^4.17.21",
-        "marked": "^4.1.0",
-        "marked-terminal": "^5.1.1",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^4.0.0",
+        "lodash": "^4.17.21",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
-        "p-each-series": "^3.0.0",
-        "p-reduce": "^3.0.0",
-        "read-pkg-up": "^9.1.0",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^4.0.0",
+        "semver-diff": "^3.1.1",
         "signale": "^1.2.1",
-        "yargs": "^17.5.1"
+        "yargs": "^16.2.0"
       },
       "bin": {
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/semantic-release/node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/execa": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^3.0.1",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^7.5.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release/node_modules/human-signals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/locate-path": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-      "integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/read-pkg": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/read-pkg-up": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^7.1.0",
-        "type-fest": "^2.5.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=16 || ^14.17"
       }
     },
     "node_modules/semantic-release/node_modules/resolve-from": {
@@ -9456,40 +9078,31 @@
         "node": ">=10"
       }
     },
-    "node_modules/semantic-release/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=10"
       }
     },
-    "node_modules/semantic-release/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+    "node_modules/semantic-release/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -9502,42 +9115,33 @@
       }
     },
     "node_modules/semver-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-      "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^6.3.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/semver-diff/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-regex": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
-      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10568,6 +10172,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.6.2",
@@ -11932,6 +11545,12 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -12511,6 +12130,17 @@
         "string-width": "^4.2.0"
       }
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12629,15 +12259,16 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
-      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
+        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0"
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       }
     },
     "create-require": {
@@ -12852,80 +12483,14 @@
       }
     },
     "env-ci": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-8.0.0.tgz",
-      "integrity": "sha512-W+3BqGZozFua9MPeXpmTm5eYEBtGgL76jGu/pwMVp/L8PdECSCEWaIp7d4Mw7kuUrbUldK0oV0bNd6ZZjLiMiA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
       "requires": {
-        "execa": "^6.1.0",
-        "java-properties": "^1.0.2"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^3.0.1",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
-        }
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
+        "java-properties": "^1.0.0"
       }
     },
     "error-ex": {
@@ -13240,19 +12805,18 @@
       }
     },
     "figures": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^5.0.0",
-        "is-unicode-supported": "^1.2.0"
+        "escape-string-regexp": "^1.0.5"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
         }
       }
@@ -13291,12 +12855,12 @@
       }
     },
     "find-versions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
-      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "dev": true,
       "requires": {
-        "semver-regex": "^4.0.5"
+        "semver-regex": "^3.1.2"
       }
     },
     "flat-cache": {
@@ -13324,6 +12888,12 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
+    },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -13517,9 +13087,9 @@
       "dev": true
     },
     "hook-std": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
-      "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
       "dev": true
     },
     "hosted-git-info": {
@@ -13735,12 +13305,6 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
-    },
-    "is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -14446,12 +14010,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
     "lodash.capitalize": {
@@ -16668,9 +16226,9 @@
       }
     },
     "p-each-series": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
-      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "p-filter": {
@@ -16713,9 +16271,9 @@
       "dev": true
     },
     "p-reduce": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
-      "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
       "dev": true
     },
     "p-retry": {
@@ -17268,9 +16826,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semantic-release": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-20.0.2.tgz",
-      "integrity": "sha512-K6TYMAnSUqM2oH0/0ZJErMzkx4SgV2dM8jh5RNGj1ANJ81z/u5XVaPPCZADAl7voEf6t2hd6YioLd0I6yXui2A==",
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -17278,204 +16836,31 @@
         "@semantic-release/github": "^8.0.0",
         "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^4.0.1",
-        "cosmiconfig": "^8.0.0",
+        "aggregate-error": "^3.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^8.0.0",
-        "execa": "^6.1.0",
-        "figures": "^5.0.0",
-        "find-versions": "^5.1.0",
+        "env-ci": "^5.0.0",
+        "execa": "^5.0.0",
+        "figures": "^3.0.0",
+        "find-versions": "^4.0.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^3.0.0",
-        "hosted-git-info": "^6.0.0",
-        "lodash-es": "^4.17.21",
-        "marked": "^4.1.0",
-        "marked-terminal": "^5.1.1",
+        "hook-std": "^2.0.0",
+        "hosted-git-info": "^4.0.0",
+        "lodash": "^4.17.21",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
-        "p-each-series": "^3.0.0",
-        "p-reduce": "^3.0.0",
-        "read-pkg-up": "^9.1.0",
+        "p-each-series": "^2.1.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^7.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^4.0.0",
+        "semver-diff": "^3.1.1",
         "signale": "^1.2.1",
-        "yargs": "^17.5.1"
+        "yargs": "^16.2.0"
       },
       "dependencies": {
-        "aggregate-error": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-          "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-          "dev": true,
-          "requires": {
-            "clean-stack": "^4.0.0",
-            "indent-string": "^5.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-          "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "5.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-          "dev": true
-        },
-        "execa": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.1",
-            "human-signals": "^3.0.1",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^3.0.7",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "find-up": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^7.1.0",
-            "path-exists": "^5.0.0"
-          }
-        },
-        "hosted-git-info": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-          "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^7.5.1"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "7.14.1",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-              "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
-              "dev": true
-            }
-          }
-        },
-        "human-signals": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-          "integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^6.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^4.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-          "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.1",
-            "normalize-package-data": "^3.0.2",
-            "parse-json": "^5.2.0",
-            "type-fest": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-          "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-          "dev": true,
-          "requires": {
-            "find-up": "^6.3.0",
-            "read-pkg": "^7.1.0",
-            "type-fest": "^2.5.0"
-          }
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -17491,22 +16876,25 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "strip-final-newline": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-          "dev": true
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
         },
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-          "dev": true
-        },
-        "yocto-queue": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
@@ -17518,29 +16906,26 @@
       "dev": true
     },
     "semver-diff": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-      "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "dev": true,
       "requires": {
-        "semver": "^7.3.5"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
     "semver-regex": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
-      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "shebang-command": {
@@ -18299,6 +17684,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "litra-glow",
+  "name": "litra",
   "version": "0.0.0-development",
-  "description": "A driver for controlling your Logitech Litra Glow light from a CLI or your JavaScript code",
+  "description": "A driver for controlling Logitech Litra devices, including the Logitech Litra Glow and Logitech Litra Beam, from a CLI or your JavaScript code",
   "main": "./dist/commonjs/driver.js",
   "module": "./dist/esm/driver.js",
-  "homepage": "https://github.com/timrogers/litra-glow",
+  "homepage": "https://github.com/timrogers/litra",
   "files": [
     "dist"
   ],
@@ -34,11 +34,11 @@
     "ts-jest": "^29.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3",
-    "semantic-release": "^20.0.2"
+    "semantic-release": "^19.0.5"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/timrogers/litra-glow.git"
+    "url": "https://github.com/timrogers/litra.git"
   },
   "release": {
     "branches": ["main"]

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -2,6 +2,11 @@ import HID from 'node-hid';
 
 import { integerToBytes, padRight, percentageWithinRange } from './utils';
 
+export enum DeviceType {
+  LitraGlow = 'litra_glow',
+  LitraBeam = 'litra_beam',
+}
+
 const VENDOR_ID = 0x046d;
 const PRODUCT_IDS = [
   0xc900, // Litra Glow
@@ -9,19 +14,41 @@ const PRODUCT_IDS = [
 ];
 const USAGE_PAGE = 0xff43;
 
+const MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+  [DeviceType.LitraGlow]: 20,
+  [DeviceType.LitraBeam]: 20,
+};
+
+const MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE = {
+  [DeviceType.LitraGlow]: 250,
+  [DeviceType.LitraBeam]: 400,
+};
+
+const MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+  [DeviceType.LitraGlow]: 2700,
+  [DeviceType.LitraBeam]: 2700,
+};
+
+const MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE = {
+  [DeviceType.LitraGlow]: 6500,
+  [DeviceType.LitraBeam]: 6500,
+};
+
 // Conforms to the interface of `node-hid`'s `HID.HID`. Useful for mocking.
 export interface Device {
-  write: (values: number[] | Buffer) => number;
+  hid: {
+    write: (values: number[] | Buffer) => number;
+  };
+  type: DeviceType;
 }
 
 /**
- * Finds your Logitech Litra Glow device and returns it. Returns `null`
- * if a matching device cannot be found connected to your computer.
+ * Finds your Logitech Litra device and returns it. Returns `null` if a
+ * supported device cannot be found connected to your computer.
  *
- * @returns {Device, null} An object representing your Logitech Litra
- * Glow device, passed into other functions like `turnOn` and
- * `setTemperatureInKelvin` - or `null` if a matching device cannot be
- * found connected to your computer.
+ * @returns {Device, null} An object representing your Logitech Litra device,
+ * passed into other functions like `turnOn` and `setTemperatureInKelvin` -
+ * or `null` if a matching device cannot be found connected to your computer.
  */
 export const findDevice = (): Device | null => {
   const matchingDevice = HID.devices().find(
@@ -32,39 +59,40 @@ export const findDevice = (): Device | null => {
   );
 
   if (matchingDevice) {
-    return new HID.HID(matchingDevice.path as string);
+    return {
+      type: getDeviceTypeByProductId(matchingDevice.productId),
+      hid: new HID.HID(matchingDevice.path as string),
+    };
   } else {
     return null;
   }
 };
 
 /**
- * Turns your Logitech Litra Glow device on.
+ * Turns your Logitech Litra device on.
  *
  * @param {Device} device The device to set the temperature of
  */
 export const turnOn = (device: Device): void => {
-  device.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
+  device.hid.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x01], 20, 0x00));
 };
 
 /**
- * Turns your Logitech Litra Glow device off.
+ * Turns your Logitech Litra device off.
  *
  * @param {Device} device The device to set the temperature of
  */
 export const turnOff = (device: Device): void => {
-  device.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
+  device.hid.write(padRight([0x11, 0xff, 0x04, 0x1c, 0x00], 20, 0x00));
 };
 
-const MINIMUM_TEMPERATURE_IN_KELVIN = 2700;
-const MAXIMUM_TEMPERATURE_IN_KELVIN = 6500;
-
 /**
- * Sets the temperature of your Logitech Litra Glow device
+ * Sets the temperature of your Logitech Litra device
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} temperatureInKelvin The temperature to set in Kelvin, which
- * must be an integer between 2700 and 6500
+ * @param {number} temperatureInKelvin The temperature to set in Kelvin. Use the
+ *  `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice`
+ *  functions to get the minimum and maximum temperature for your device.
  */
 export const setTemperatureInKelvin = (
   device: Device,
@@ -74,20 +102,23 @@ export const setTemperatureInKelvin = (
     throw 'Provided temperature must be an integer';
   }
 
+  const minimumTemperature = getMinimumTemperatureInKelvinForDevice(device);
+  const maximumTemperature = getMaximumTemperatureInKelvinForDevice(device);
+
   if (
-    temperatureInKelvin < MINIMUM_TEMPERATURE_IN_KELVIN ||
-    temperatureInKelvin > MAXIMUM_TEMPERATURE_IN_KELVIN
+    temperatureInKelvin < minimumTemperature ||
+    temperatureInKelvin > maximumTemperature
   ) {
-    throw `Provided temperature must be between ${MINIMUM_TEMPERATURE_IN_KELVIN} and ${MAXIMUM_TEMPERATURE_IN_KELVIN}`;
+    throw `Provided temperature must be between ${minimumTemperature} and ${maximumTemperature} for this device`;
   }
 
-  device.write(
+  device.hid.write(
     padRight([0x11, 0xff, 0x04, 0x9c, ...integerToBytes(temperatureInKelvin)], 20, 0x00),
   );
 };
 
 /**
- * Set the temperature of your Logitech Litra Glow device to a percentage
+ * Set the temperature of your Logitech Litra device to a percentage
  * of the device's maximum temperature
  *
  * @param {Device} device The device to set the temperature of
@@ -101,45 +132,46 @@ export const setTemperaturePercentage = (
     throw 'Percentage must be between 0 and 100';
   }
 
+  const minimumTemperature = getMinimumTemperatureInKelvinForDevice(device);
+  const maximumTemperature = getMaximumTemperatureInKelvinForDevice(device);
+
   return setTemperatureInKelvin(
     device,
     temperaturePercentage === 0
-      ? MINIMUM_TEMPERATURE_IN_KELVIN
+      ? minimumTemperature
       : percentageWithinRange(
           temperaturePercentage,
-          MINIMUM_TEMPERATURE_IN_KELVIN,
-          MAXIMUM_TEMPERATURE_IN_KELVIN,
+          minimumTemperature,
+          maximumTemperature,
         ),
   );
 };
 
-const MINIMUM_BRIGHTNESS_IN_LUMEN = 20;
-const MAXIMUM_BRIGHTNESS_IN_LUMEN = 250;
-
 /**
- * Sets the brightness of your Logitech Litra Glow device, measured in Lumen
+ * Sets the brightness of your Logitech Litra device, measured in Lumen
  *
  * @param {Device} device The device to set the temperature of
- * @param {number} brightnessInLumens The brightness to set in Lumen, which
- * must be an integer between 20 and 250
+ * @param {number} brightnessInLumen The brightness to set in Lumen. Use the
+ *  `getMinimumBrightnessInLumenForDevice` and `getMaximumBrightnessInLumenForDevice`
+ *  functions to get the minimum and maximum brightness for your device.
  */
 export const setBrightnessInLumen = (device: Device, brightnessInLumen: number): void => {
   if (!Number.isInteger(brightnessInLumen)) {
     throw 'Provided brightness must be an integer';
   }
 
-  if (
-    brightnessInLumen < MINIMUM_BRIGHTNESS_IN_LUMEN ||
-    brightnessInLumen > MAXIMUM_BRIGHTNESS_IN_LUMEN
-  ) {
-    throw `Provided brightness must be between ${MINIMUM_BRIGHTNESS_IN_LUMEN} and ${MAXIMUM_BRIGHTNESS_IN_LUMEN}`;
+  const minimumBrightness = getMinimumBrightnessInLumenForDevice(device);
+  const maximumBrightness = getMaximumBrightnessInLumenForDevice(device);
+
+  if (brightnessInLumen < minimumBrightness || brightnessInLumen > maximumBrightness) {
+    throw `Provided brightness must be between ${minimumBrightness} and ${maximumBrightness} for this device`;
   }
 
-  device.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
+  device.hid.write(padRight([0x11, 0xff, 0x04, 0x4c, 0x00, brightnessInLumen], 20, 0x00));
 };
 
 /**
- * Set the brightness of your Logitech Litra Glow device to a percentage
+ * Set the brightness of your Logitech Litra device to a percentage
  * of the device's maximum brightness
  *
  * @param {Device} device The device to set the brightness of
@@ -153,14 +185,70 @@ export const setBrightnessPercentage = (
     throw 'Percentage must be between 0 and 100';
   }
 
+  const minimumBrightness = getMinimumBrightnessInLumenForDevice(device);
+  const maximumBrightness = getMaximumBrightnessInLumenForDevice(device);
+
   return setBrightnessInLumen(
     device,
     brightnessPercentage === 0
-      ? MINIMUM_BRIGHTNESS_IN_LUMEN
-      : percentageWithinRange(
-          brightnessPercentage,
-          MINIMUM_BRIGHTNESS_IN_LUMEN,
-          MAXIMUM_BRIGHTNESS_IN_LUMEN,
-        ),
+      ? minimumBrightness
+      : percentageWithinRange(brightnessPercentage, minimumBrightness, maximumBrightness),
   );
+};
+
+/**
+ * Gets the type of a Logitech Litra device by its product IOD
+ *
+ * @param {number} productId The product ID of the device
+ * @returns {DeviceType} The type of the device
+ */
+const getDeviceTypeByProductId = (productId: number): DeviceType => {
+  switch (productId) {
+    case 0xc900:
+      return DeviceType.LitraGlow;
+    case 0xc901:
+      return DeviceType.LitraBeam;
+    default:
+      throw 'Unknown device type';
+  }
+};
+
+/**
+ * Gets the minimum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the minimum brightness for
+ * @returns {number} The minimum brightness in Lumen supported by the device
+ */
+export const getMinimumBrightnessInLumenForDevice = (device: Device): number => {
+  return MINIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+
+/**
+ * Gets the maximum brightness in Lumen supported by a device
+ *
+ * @param {Device} device The device to check the maximum brightness for
+ * @returns {number} The maximum brightness in Lumen supported by the device
+ */
+export const getMaximumBrightnessInLumenForDevice = (device: Device): number => {
+  return MAXIMUM_BRIGHTNESS_IN_LUMEN_BY_DEVICE_TYPE[device.type];
+};
+
+/**
+ * Gets the minimum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the minimum temperature for
+ * @returns {number} The minimum temperature in Kelvin supported by the device
+ */
+export const getMinimumTemperatureInKelvinForDevice = (device: Device): number => {
+  return MINIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
+};
+
+/**
+ * Gets the maximum temperature in Kelvin supported by a device
+ *
+ * @param {Device} device The device to check the maximum temperature for
+ * @returns {number} The maximum temperature in Kelvin supported by the device
+ */
+export const getMaximumTemperatureInKelvinForDevice = (device: Device): number => {
+  return MAXIMUM_TEMPERATURE_IN_KELVIN_BY_DEVICE_TYPE[device.type];
 };

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -3,7 +3,10 @@ import HID from 'node-hid';
 import { integerToBytes, padRight, percentageWithinRange } from './utils';
 
 const VENDOR_ID = 0x046d;
-const PRODUCT_ID = 0xc900;
+const PRODUCT_IDS = [
+  0xc900, // Litra Glow
+  0xc901, // Litra Beam
+];
 const USAGE_PAGE = 0xff43;
 
 // Conforms to the interface of `node-hid`'s `HID.HID`. Useful for mocking.
@@ -24,7 +27,7 @@ export const findDevice = (): Device | null => {
   const matchingDevice = HID.devices().find(
     (device) =>
       device.vendorId === VENDOR_ID &&
-      device.productId === PRODUCT_ID &&
+      PRODUCT_IDS.includes(device.productId) &&
       device.usagePage === USAGE_PAGE,
   );
 

--- a/tests/driver.test.ts
+++ b/tests/driver.test.ts
@@ -1,4 +1,9 @@
 import {
+  DeviceType,
+  getMaximumBrightnessInLumenForDevice,
+  getMinimumBrightnessInLumenForDevice,
+  getMaximumTemperatureInKelvinForDevice,
+  getMinimumTemperatureInKelvinForDevice,
   setBrightnessInLumen,
   setBrightnessPercentage,
   setTemperatureInKelvin,
@@ -9,11 +14,11 @@ import {
 
 describe('turnOn', () => {
   it('sends the instruction to turn the device on', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     turnOn(fakeDevice);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeDevice.hid.write).toBeCalledWith([
       17, 255, 4, 28, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
@@ -21,11 +26,11 @@ describe('turnOn', () => {
 
 describe('turnOff', () => {
   it('sends the instruction to turn the device off', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     turnOff(fakeDevice);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeDevice.hid.write).toBeCalledWith([
       17, 255, 4, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
@@ -33,33 +38,45 @@ describe('turnOff', () => {
 
 describe('setTemperatureInKelvin', () => {
   it('sends the instruction to set the device temperature', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     setTemperatureInKelvin(fakeDevice, 6300);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeDevice.hid.write).toBeCalledWith([
       17, 255, 4, 156, 24, 156, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
-  it('throws an error if the temperature is below the minimum', () => {
-    const fakeDevice = { write: jest.fn() };
+  it('throws an error if the temperature is below the minimum for the device', () => {
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    expect(() => setTemperatureInKelvin(fakeDevice, 2699)).toThrowError(
+    expect(() => setTemperatureInKelvin(fakeLitraGlow, 2699)).toThrowError(
+      'Provided temperature must be between 2700 and 6500',
+    );
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    expect(() => setTemperatureInKelvin(fakeLitraBeam, 2699)).toThrowError(
       'Provided temperature must be between 2700 and 6500',
     );
   });
 
-  it('throws an error if the temperature is above the maximum', () => {
-    const fakeDevice = { write: jest.fn() };
+  it('throws an error if the temperature is above the maximum for the device', () => {
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    expect(() => setTemperatureInKelvin(fakeDevice, 6501)).toThrowError(
+    expect(() => setTemperatureInKelvin(fakeLitraGlow, 6501)).toThrowError(
+      'Provided temperature must be between 2700 and 6500',
+    );
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    expect(() => setTemperatureInKelvin(fakeLitraBeam, 6501)).toThrowError(
       'Provided temperature must be between 2700 and 6500',
     );
   });
 
   it('throws an error if the temperature is not an integer', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setTemperatureInKelvin(fakeDevice, 1337.9)).toThrowError(
       'Provided temperature must be an integer',
@@ -68,28 +85,44 @@ describe('setTemperatureInKelvin', () => {
 });
 
 describe('setTemperaturePercentage', () => {
-  it('sends the instruction to set the device temperature based on a percentage', () => {
-    const fakeDevice = { write: jest.fn() };
+  it('sends the instruction to set the device temperature based on a percentage, ', () => {
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    setTemperaturePercentage(fakeDevice, 100);
+    setTemperaturePercentage(fakeLitraGlow, 100);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeLitraGlow.hid.write).toBeCalledWith([
+      17, 255, 4, 156, 25, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    setTemperaturePercentage(fakeLitraBeam, 100);
+
+    expect(fakeLitraBeam.hid.write).toBeCalledWith([
       17, 255, 4, 156, 25, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
   it('sends the instruction to set the device temperature to the minimum temperature when set to 0%', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    setTemperaturePercentage(fakeDevice, 0);
+    setTemperaturePercentage(fakeLitraGlow, 0);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeLitraGlow.hid.write).toBeCalledWith([
+      17, 255, 4, 156, 10, 140, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    setTemperaturePercentage(fakeLitraBeam, 0);
+
+    expect(fakeLitraBeam.hid.write).toBeCalledWith([
       17, 255, 4, 156, 10, 140, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
   it('throws an error if the provided percentage is less than 0', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setTemperaturePercentage(fakeDevice, -1)).toThrowError(
       'Percentage must be between 0 and 100',
@@ -97,7 +130,7 @@ describe('setTemperaturePercentage', () => {
   });
 
   it('throws an error if the provided percentage is more than 100', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setTemperaturePercentage(fakeDevice, 101)).toThrowError(
       'Percentage must be between 0 and 100',
@@ -107,33 +140,45 @@ describe('setTemperaturePercentage', () => {
 
 describe('setBrightnessInLumen', () => {
   it('sends the instruction to set the device temperature', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     setBrightnessInLumen(fakeDevice, 20);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeDevice.hid.write).toBeCalledWith([
       17, 255, 4, 76, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
-  it('throws an error if the brightness is below the minimum', () => {
-    const fakeDevice = { write: jest.fn() };
+  it('throws an error if the brightness is below the minimum for the device', () => {
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    expect(() => setBrightnessInLumen(fakeDevice, 19)).toThrowError(
+    expect(() => setBrightnessInLumen(fakeLitraGlow, 19)).toThrowError(
       'Provided brightness must be between 20 and 250',
+    );
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    expect(() => setBrightnessInLumen(fakeLitraBeam, 19)).toThrowError(
+      'Provided brightness must be between 20 and 400',
     );
   });
 
-  it('throws an error if the brightness is above the maximum', () => {
-    const fakeDevice = { write: jest.fn() };
+  it('throws an error if the brightness is above the maximum for the device', () => {
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    expect(() => setBrightnessInLumen(fakeDevice, 251)).toThrowError(
+    expect(() => setBrightnessInLumen(fakeLitraGlow, 251)).toThrowError(
       'Provided brightness must be between 20 and 250',
+    );
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    expect(() => setBrightnessInLumen(fakeLitraBeam, 401)).toThrowError(
+      'Provided brightness must be between 20 and 400',
     );
   });
 
   it('throws an error if the brightness is not an integer', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setBrightnessInLumen(fakeDevice, 1337.9)).toThrowError(
       'Provided brightness must be an integer',
@@ -143,27 +188,43 @@ describe('setBrightnessInLumen', () => {
 
 describe('setBrightnessPercentage', () => {
   it('sends the instruction to set the device brightness based on a percentage', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    setBrightnessPercentage(fakeDevice, 100);
+    setBrightnessPercentage(fakeLitraGlow, 100);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeLitraGlow.hid.write).toBeCalledWith([
       17, 255, 4, 76, 0, 250, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    setBrightnessPercentage(fakeLitraBeam, 100);
+
+    expect(fakeLitraBeam.hid.write).toBeCalledWith([
+      17, 255, 4, 76, 0, 400, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
   it('sends the instruction to set the device brightness to the minimum brightness when set to 0%', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeLitraGlow = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
-    setBrightnessPercentage(fakeDevice, 0);
+    setBrightnessPercentage(fakeLitraGlow, 0);
 
-    expect(fakeDevice.write).toBeCalledWith([
+    expect(fakeLitraGlow.hid.write).toBeCalledWith([
+      17, 255, 4, 76, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const fakeLitraBeam = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+
+    setBrightnessPercentage(fakeLitraBeam, 0);
+
+    expect(fakeLitraBeam.hid.write).toBeCalledWith([
       17, 255, 4, 76, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]);
   });
 
   it('throws an error if the provided percentage is less than 0', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setBrightnessPercentage(fakeDevice, -1)).toThrowError(
       'Percentage must be between 0 and 100',
@@ -171,10 +232,58 @@ describe('setBrightnessPercentage', () => {
   });
 
   it('throws an error if the provided percentage is more than 100', () => {
-    const fakeDevice = { write: jest.fn() };
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
 
     expect(() => setBrightnessPercentage(fakeDevice, 101)).toThrowError(
       'Percentage must be between 0 and 100',
     );
+  });
+});
+
+describe('getMinimumBrightnessInLumenForDevice', () => {
+  it('returns the correct minimum brightness for a Litra Glow', () => {
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
+    expect(getMinimumBrightnessInLumenForDevice(fakeDevice)).toEqual(20);
+  });
+
+  it('returns the correct minimum brightness for a Litra Beam', () => {
+    const fakeDevice = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+    expect(getMinimumBrightnessInLumenForDevice(fakeDevice)).toEqual(20);
+  });
+});
+
+describe('getMaximumBrightnessInLumenForDevice', () => {
+  it('returns the correct maximum brightness for a Litra Glow', () => {
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
+    expect(getMaximumBrightnessInLumenForDevice(fakeDevice)).toEqual(250);
+  });
+
+  it('returns the correct maximum brightness for a Litra Beam', () => {
+    const fakeDevice = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+    expect(getMaximumBrightnessInLumenForDevice(fakeDevice)).toEqual(400);
+  });
+});
+
+describe('getMinimumTemperatureInKelvinForDevice', () => {
+  it('returns the correct minimum temperature for a Litra Glow', () => {
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
+    expect(getMinimumTemperatureInKelvinForDevice(fakeDevice)).toEqual(2700);
+  });
+
+  it('returns the correct minimum temperature for a Litra Beam', () => {
+    const fakeDevice = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+    expect(getMinimumTemperatureInKelvinForDevice(fakeDevice)).toEqual(2700);
+  });
+});
+
+describe('getMaximumTemperatureInKelvinForDevice', () => {
+  it('returns the correct maximum temperature for a Litra Glow', () => {
+    const fakeDevice = { type: DeviceType.LitraGlow, hid: { write: jest.fn() } };
+    expect(getMaximumTemperatureInKelvinForDevice(fakeDevice)).toEqual(6500);
+  });
+
+  it('returns the correct maximum temperature for a Litra Beam', () => {
+    const fakeDevice = { type: DeviceType.LitraBeam, hid: { write: jest.fn() } };
+    expect(getMaximumTemperatureInKelvinForDevice(fakeDevice)).toEqual(6500);
   });
 });


### PR DESCRIPTION
This picks up @StevenRudenko's fantastic work in #64 on adding support for the Logitech Litra Beam, and gets it ready for release.

In this PR, we:

* add support for the new device type
* expose a `type` on `Device`s returned by `findDevice` so you can see what device is detected
* add new `getMinimumBrightnessInLumenForDevice`, `getMaximumBrightnessInLumenForDevice`, `getMinimumTemperatureInKelvinForDevice` and `getMaximumTemperatureInKelvinForDevice` functions for getting device-specific limits on brightness and temperature
* apply device-specific temperature and brightness limits when setting temperature and brightness to a percentage
* enforce device-specific temperature and brightness limits when setting temperature and brightness to a number in Kelvin or Lumen
* rename the package to `litra`, reflecting our wider support for more devices